### PR TITLE
Move welcome page and add simple home

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,7 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
-export default [index("routes/home.tsx")] satisfies RouteConfig;
+export default [
+  index("routes/home.tsx"),
+  route("welcome", "routes/welcome.tsx"),
+  route("test", "routes/test.tsx"),
+] satisfies RouteConfig;

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,13 +1,22 @@
 import type { Route } from "./+types/home";
-import { Welcome } from "../welcome/welcome";
+import { Link } from "react-router";
 
 export function meta({}: Route.MetaArgs) {
   return [
-    { title: "New React Router App" },
-    { name: "description", content: "Welcome to React Router!" },
+    { title: "トップページ" },
+    { name: "description", content: "シンプルなトップページ" },
   ];
 }
 
 export default function Home() {
-  return <Welcome />;
+  return (
+    <main className="pt-16 p-4 container mx-auto space-y-4">
+      <h1 className="text-xl font-bold">トップページ</h1>
+      <p>
+        <Link to="/test" className="text-blue-700 hover:underline">
+          /test へ移動
+        </Link>
+      </p>
+    </main>
+  );
 }

--- a/app/routes/test.tsx
+++ b/app/routes/test.tsx
@@ -1,0 +1,16 @@
+import type { Route } from "./+types/test";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Test Page" },
+    { name: "description", content: "Dummy text page" },
+  ];
+}
+
+export default function Test() {
+  return (
+    <main className="pt-16 p-4 container mx-auto">
+      <p>ダミーテキストです。</p>
+    </main>
+  );
+}

--- a/app/routes/welcome.tsx
+++ b/app/routes/welcome.tsx
@@ -1,0 +1,13 @@
+import type { Route } from "./+types/welcome";
+import { Welcome } from "../welcome/welcome";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "New React Router App" },
+    { name: "description", content: "Welcome to React Router!" },
+  ];
+}
+
+export default function WelcomeRoute() {
+  return <Welcome />;
+}


### PR DESCRIPTION
## Summary
- `/welcome` ページを新設し、元の `welcome.tsx` 内容を移動
- ルート `/` をシンプルなトップページに変更し、`/test` へのリンクを表示
- `routes.ts` に新ルートを追加

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6847b62c722083218d26a62e65f9273a