### PR TITLE
Add sidebar navigation

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,0 +1,24 @@
+import { NavLink } from "react-router";
+
+export function Sidebar() {
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    [
+      "block px-3 py-2 rounded",
+      isActive
+        ? "bg-blue-500 text-white"
+        : "text-blue-700 hover:bg-blue-100",
+    ].join(" ");
+
+  return (
+    <aside className="w-48 shrink-0 h-screen bg-gray-100 p-4">
+      <nav className="space-y-2">
+        <NavLink to="/" end className={linkClass}>
+          /
+        </NavLink>
+        <NavLink to="/test" className={linkClass}>
+          /test
+        </NavLink>
+      </nav>
+    </aside>
+  );
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,6 +6,9 @@ import {
   Scripts,
   ScrollRestoration,
 } from "react-router";
+import { useLocation } from "react-router";
+
+import { Sidebar } from "./components/Sidebar";
 
 import type { Route } from "./+types/root";
 import "./app.css";
@@ -42,7 +45,21 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  return <Outlet />;
+  const location = useLocation();
+  const showSidebar = !location.pathname.startsWith("/welcome");
+
+  if (!showSidebar) {
+    return <Outlet />;
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex-1">
+        <Outlet />
+      </div>
+    </div>
+  );
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {


### PR DESCRIPTION
## Summary
- create `Sidebar` component with links to `/` and `/test`
- show the sidebar for all pages except `/welcome`
- highlight the active link

## Testing
- `npm run typecheck` *(fails: react-router not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c4c0f88c83219b5335f5ba283333