### PR TITLE
Improve compare file input UX

### DIFF
--- a/app/routes/compare.tsx
+++ b/app/routes/compare.tsx
@@ -84,11 +84,11 @@ export default function Test() {
             type="file"
             accept="text/*"
             onChange={handleFileA}
-            className="block mt-1 text-sm file:mr-2 file:rounded file:border file:border-gray-300 file:bg-gray-50 file:px-2 file:py-1 file:text-gray-700 hover:file:bg-gray-100"
+            className="block mt-1 text-sm file:mr-2 file:rounded file:border file:border-gray-300 file:bg-gray-50 file:px-2 file:py-1 file:text-gray-700 hover:file:bg-gray-100 text-transparent cursor-pointer"
           />
-          {fileAName && (
-            <div className="mt-1 text-sm break-all">{fileAName}</div>
-          )}
+          <div className="mt-1 text-sm overflow-x-auto whitespace-nowrap">
+            {fileAName || "選択されていません"}
+          </div>
           <textarea
             id="areaA"
             rows={10}
@@ -106,11 +106,11 @@ export default function Test() {
             type="file"
             accept="text/*"
             onChange={handleFileB}
-            className="block mt-1 text-sm file:mr-2 file:rounded file:border file:border-gray-300 file:bg-gray-50 file:px-2 file:py-1 file:text-gray-700 hover:file:bg-gray-100"
+            className="block mt-1 text-sm file:mr-2 file:rounded file:border file:border-gray-300 file:bg-gray-50 file:px-2 file:py-1 file:text-gray-700 hover:file:bg-gray-100 text-transparent cursor-pointer"
           />
-          {fileBName && (
-            <div className="mt-1 text-sm break-all">{fileBName}</div>
-          )}
+          <div className="mt-1 text-sm overflow-x-auto whitespace-nowrap">
+            {fileBName || "選択されていません"}
+          </div>
           <textarea
             id="areaB"
             rows={10}


### PR DESCRIPTION
## Summary
- show message when no file selected
- hide default file name from file input
- allow long file names to scroll horizontally

## Testing
- `npm run typecheck` *(fails: react-router not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e33d0240832181781d3057fad8c0