### PR TITLE
Use monospaced font in compare page

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -3,6 +3,8 @@
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-mono: "M PLUS 1 Code", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 html,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -24,6 +24,10 @@ export const links: Route.LinksFunction = () => [
     rel: "stylesheet",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
+  {
+    rel: "stylesheet",
+    href: "https://fonts.googleapis.com/css2?family=M+PLUS+1+Code&display=swap",
+  },
 ];
 
 export function Layout({ children }: { children: React.ReactNode }) {

--- a/app/routes/compare.tsx
+++ b/app/routes/compare.tsx
@@ -106,7 +106,7 @@ export default function Test() {
           value={textA}
           onChange={(e) => setTextA(e.target.value)}
           wrap="off"
-          className="w-full border p-2 rounded mt-1 overflow-x-auto whitespace-pre col-start-1 row-start-2"
+          className="w-full border p-2 rounded mt-1 overflow-x-auto whitespace-pre col-start-1 row-start-2 font-mono"
         />
         <textarea
           id="areaB"
@@ -114,7 +114,7 @@ export default function Test() {
           value={textB}
           onChange={(e) => setTextB(e.target.value)}
           wrap="off"
-          className="w-full border p-2 rounded mt-1 overflow-x-auto whitespace-pre col-start-2 row-start-2"
+          className="w-full border p-2 rounded mt-1 overflow-x-auto whitespace-pre col-start-2 row-start-2 font-mono"
         />
       </div>
       <div className="space-x-4">
@@ -141,7 +141,7 @@ export default function Test() {
           どっちかにしかない単語
         </label>
       </div>
-      <ul className="list-disc pl-6 overflow-x-auto whitespace-nowrap">
+      <ul className="list-disc pl-6 overflow-x-auto whitespace-nowrap font-mono">
         {results.map((r) => (
           <li key={r.word} className="whitespace-nowrap">
             {r.word}


### PR DESCRIPTION
## Summary
- load **M PLUS 1 Code** font
- set `--font-mono` variable to the new font
- apply `font-mono` class on `/compare` text areas and result list

## Testing
- `npm run typecheck` *(fails: react-router not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ee61700083218992fde904c487f4