### PR TITLE
Add /ex route with Extract component

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -21,6 +21,9 @@ export function Sidebar() {
         <NavLink to="/dup" className={linkClass}>
           /dup
         </NavLink>
+        <NavLink to="/ex" className={linkClass}>
+          /ex
+        </NavLink>
       </nav>
     </aside>
   );

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -5,4 +5,5 @@ export default [
   route("welcome", "routes/welcome.tsx"),
   route("test", "routes/test.tsx"),
   route("dup", "routes/dup.tsx"),
+  route("ex", "routes/ex.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/ex.tsx
+++ b/app/routes/ex.tsx
@@ -1,0 +1,16 @@
+import type { Route } from "./+types/ex";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Extract Page" },
+    { name: "description", content: "データ抽出ページ" },
+  ];
+}
+
+export default function Extract() {
+  return (
+    <main className="pt-16 p-4 container mx-auto">
+      <p>ここは抽出ページです。</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- 新しい `/ex` ルートを作成し、`Extract` コンポーネントを追加
- `routes.ts` と `Sidebar` にルート登録を追加

## Testing
- `npm install`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6849270e2e9c8321b7e8daf5191dc574