### PR TITLE
Fix prefix removal logic for edit page

### DIFF
--- a/app/routes/edit.tsx
+++ b/app/routes/edit.tsx
@@ -90,7 +90,7 @@ export default function Edit() {
       if (headOpt === "trim") {
         const prefix = input;
         const n = prefix.length;
-        result = lines.map((l) => (l.startsWith(prefix) ? l : l.slice(n)));
+        result = lines.map((l) => (l.startsWith(prefix) ? l.slice(n) : l));
       } else {
         result = lines.map((l) => l.replace(/^[ \t]+/, ""));
       }


### PR DESCRIPTION
## Summary
- fix bug removing text when line doesn't start with prefix

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684a66ad5cb88321b36d6e80db1db27d