### PR TITLE
Setup for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ The containerized application can be deployed to any platform that supports Dock
 - Fly.io
 - Railway
 
+### GitHub Pages
+
+`vite.config.ts` で `base: '/nk/'`、`react-router.config.ts` で `basename: '/nk/'` を設定しています。ビルド後に `build/client/index.html` を `build/client/404.html` にコピーすることで、直接 `/nk/edit` などにアクセスされた場合も SPA として動作します。
+
+```bash
+npm run build
+npm run postbuild
+```
+
+`build/client` ディレクトリの内容を GitHub Pages にデプロイしてください。
+
 ### DIY Deployment
 
 If you're familiar with deploying Node applications, the built-in app server is production-ready.

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "nk",
   "private": true,
   "type": "module",
+  "homepage": "https://r77tchan.github.io/nk/",
   "scripts": {
     "build": "react-router build",
+    "postbuild": "cp build/client/index.html build/client/404.html",
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",
     "typecheck": "react-router typegen && tsc"

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0;url=/nk/" />
+    <script>
+      // Preserve direct URL access for SPA routes
+      var path = location.pathname.replace(/^\/nk/, "");
+      var search = location.search || "";
+      var hash = location.hash || "";
+      location.replace('/nk/' + '#!' + path + search + hash);
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -4,4 +4,5 @@ export default {
   // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: false,
+  basename: '/nk/',
 } satisfies Config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,6 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
+  base: '/nk/',
   plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
 });


### PR DESCRIPTION
## Summary
- configure Vite `base` for deployment under `/nk/`
- set React Router `basename` to `/nk/`
- add GitHub Pages notes in README
- copy index.html to 404.html after build
- include a redirecting 404.html for SPA

## Testing
- `npm run typecheck`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684a6b0a0e2c832190bb2b94082487f5